### PR TITLE
Five commits that made a useful plugin even more useful for me (Scheme whitelisting, BG toggle, more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The colorscheme switcher plug-in for the [Vim text editor] [vim] makes it easy t
 
 Please refer to the [installation instructions] [howto-install] available on GitHub. Once you've installed the plug-in you can try it out by executing `:NextColorScheme` to switch to the next color scheme.
 
-If you didn't change the plug-in's configuration you can use the `F8` and `Shift-F8` keys to switch to the next/previous color scheme and `Control-F8` to switch to a random color scheme.
+If you didn't change the plug-in's configuration you can use the `F8` and `Shift-F8` keys to switch to the next/previous color scheme, `Control-F8` to switch to a random color scheme and `Shift-Control-F8` to switch between light and dark color schemes.
 
 ## Commands
 
@@ -21,6 +21,10 @@ Switch to the previous color scheme. After the first color scheme the cycle repe
 ### The `:RandomColorScheme` command
 
 Switch to a random color scheme. Because Vim doesn't actually expose random numbers the microseconds of the current time are used to improvise a source of randomness. It's nothing like real randomness but convincing enough for this plug-in :-).
+
+### The `:ColorSchemeToggleBG` command
+
+Switch to the next color scheme with a different background (light/dark). This really only makes sense in combination with the `g:colorscheme_switcher_keep_background` option (see below).  For when you are cycling though dark backgrounds and decide you want a light one instead.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ The colorscheme switcher plug-in for the [Vim text editor] [vim] makes it easy t
 
 ## Installation
 
-Please refer to the [installation instructions] [howto-install] available on GitHub. Once you've installed the plug-in you can try it out by executing `:NextColorScheme` to switch to the next color scheme.
+Please refer to the [installation instructions] [howto-install] available on GitHub. Once you've installed the plug-in you can try it out by executing `:ColorSchemeNext` to switch to the next color scheme.
 
 If you didn't change the plug-in's configuration you can use the `F8` and `Shift-F8` keys to switch to the next/previous color scheme, `Control-F8` to switch to a random color scheme and `Shift-Control-F8` to switch between light and dark color schemes.
 
 ## Commands
 
-### The `:NextColorScheme` command
+### The `:ColorSchemeNext` command
 
 Switch to the next color scheme. After the last color scheme the cycle repeats from the first color scheme.
 
-### The `:PrevColorScheme` command
+### The `:ColorSchemePrev` command
 
 Switch to the previous color scheme. After the first color scheme the cycle repeats from the last color scheme.
 
-### The `:RandomColorScheme` command
+### The `:ColorSchemeRandom` command
 
 Switch to a random color scheme. Because Vim doesn't actually expose random numbers the microseconds of the current time are used to improvise a source of randomness. It's nothing like real randomness but convincing enough for this plug-in :-).
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ If you set this variable to 1 (true) and cycle to the next/previous color scheme
 
 This is useful when you want to see only light or dark color schemes, for example because the sun is shining (you'll want a light background) or because it's late at night (then you'll likely prefer a dark background).
 
+### The `g:colorscheme_switcher_include` option
+
+Some plug-ins like [vim-colorschemes][vcs] and [base16-vim][b16] provide huge suites of colorschemes, which are time-consuming to cycle through.  To limit switching to just your favorites, you can set a list like this:
+
+    :let g:colorscheme_switcher_include = ['jellybeans', 'ir_black', 'default']
+
+The schemes in this option are subject to further filtering by the other options.
+
 ### The `g:colorscheme_switcher_exclude` option
 
 A list with names of color schemes to be ignored by the plug-in. By default the list is empty. Here's an example of how you can set this:
@@ -94,3 +102,5 @@ This software is licensed under the [MIT license] [mit].
 [vim]: http://www.vim.org/
 [vim_online]: http://www.vim.org/scripts/script.php?script_id=4586
 [vimrc]: http://vimdoc.sourceforge.net/htmldoc/starting.html#vimrc
+[vcs]: https://github.com/flazz/vim-colorschemes
+[b16]: https://github.com/chriskempson/base16-vim

--- a/autoload/xolox/colorscheme_switcher.vim
+++ b/autoload/xolox/colorscheme_switcher.vim
@@ -61,6 +61,7 @@ endfunction
 function! xolox#colorscheme_switcher#find_names() " {{{1
   " Get a sorted list with the available color schemes.
   let matches = {}
+  let include_list = xolox#misc#option#get('colorscheme_switcher_include', [])
   let exclude_list = xolox#misc#option#get('colorscheme_switcher_exclude', [])
   let exclude_builtins = xolox#misc#option#get('colorscheme_switcher_exclude_builtins', 0)
   for fname in split(globpath(&runtimepath, 'colors/*.vim'), '\n')
@@ -73,6 +74,11 @@ function! xolox#colorscheme_switcher#find_names() " {{{1
       endif
     endif
   endfor
+  if len(include_list) > 0
+    " An include_list was configured. Return it in user-defined order,
+    " filtering out any colorschemes not found or allowed by above rules
+    return filter(copy(include_list), 'has_key(matches, v:val)')
+  endif
   return sort(keys(matches), 1)
 endfunction
 

--- a/autoload/xolox/colorscheme_switcher.vim
+++ b/autoload/xolox/colorscheme_switcher.vim
@@ -131,6 +131,9 @@ function! xolox#colorscheme_switcher#switch_to(name) " {{{1
   " Set the global colors_name variable because some color scheme scripts fail
   " to do so or use the wrong name (for example rainbow_autumn uses autumn).
   let g:colors_name = a:name
+  " Have vim figure out the background, for color scheme scripts that don't
+  " set it
+  set background&
   " Enable the user to customize the loaded color scheme.
   silent execute 'doautocmd ColorScheme' fnameescape(a:name)
   " Restore syntax group links as the last step to make sure the syntax group

--- a/autoload/xolox/colorscheme_switcher.vim
+++ b/autoload/xolox/colorscheme_switcher.vim
@@ -41,13 +41,16 @@ endfunction
 function! xolox#colorscheme_switcher#cycle(forward) " {{{1
   " Switch to the next or previous color scheme.
   let choices = xolox#colorscheme_switcher#find_names()
-  let index = exists('g:colors_name') ? index(choices, g:colors_name) : 0
+  let index = exists('g:colors_name') ? index(choices, g:colors_name) : -1
+  if index == -1 && exists('s:last_switched_to')
+    let index = index(choices, s:last_switched_to)
+  endif
   let original_background = &background
   for i in range(len(choices))
     if a:forward
       let index = (index + 1) % len(choices)
     else
-      let index = (index ? index : len(choices)) - 1
+      let index = (index > 0 ? index : len(choices)) - 1
     endif
     call xolox#colorscheme_switcher#switch_to(choices[index])
     if !xolox#misc#option#get('colorscheme_switcher_keep_background', 0) || &background == original_background
@@ -134,6 +137,7 @@ function! xolox#colorscheme_switcher#switch_to(name) " {{{1
   call xolox#colorscheme_switcher#find_links()
   let command = xolox#misc#option#get('colorscheme_switcher_command', 'colorscheme')
   execute command fnameescape(a:name)
+  let s:last_switched_to = a:name
   " Set the global colors_name variable because some color scheme scripts fail
   " to do so or use the wrong name (for example rainbow_autumn uses autumn).
   let g:colors_name = a:name
@@ -154,6 +158,12 @@ function! xolox#colorscheme_switcher#switch_to(name) " {{{1
   if !has('gui_running')
     let &syntax = &syntax
   endif
+endfunction
+
+function! xolox#colorscheme_switcher#bgtoggle() " {{{1
+  " Toggle background between light/dark
+  let &background = (&background == 'dark' ? 'light' : 'dark')
+  call xolox#colorscheme_switcher#next()
 endfunction
 
 function! xolox#colorscheme_switcher#random_number(limit) " {{{1

--- a/autoload/xolox/colorscheme_switcher.vim
+++ b/autoload/xolox/colorscheme_switcher.vim
@@ -51,7 +51,7 @@ function! xolox#colorscheme_switcher#cycle(forward) " {{{1
     endif
     call xolox#colorscheme_switcher#switch_to(choices[index])
     if !xolox#misc#option#get('colorscheme_switcher_keep_background', 0) || &background == original_background
-      call xolox#misc#msg#info('colorscheme-switcher.vim %s: Loaded color scheme %s (%i/%i)', g:xolox#colorscheme_switcher#version, choices[index], index, len(choices))
+      call xolox#misc#msg#info('colorscheme-switcher.vim %s: Loaded color scheme %s (%i/%i)', g:xolox#colorscheme_switcher#version, choices[index], index+1, len(choices))
       return
     endif
   endfor

--- a/doc/colorscheme-switcher.txt
+++ b/doc/colorscheme-switcher.txt
@@ -12,9 +12,10 @@ Contents ~
  4. Options                                      |colorscheme-switcher-options|
   1. The |g:colorscheme_switcher_define_mappings| option
   2. The |g:colorscheme_switcher_keep_background| option
-  3. The |g:colorscheme_switcher_exclude| option
-  4. The |g:colorscheme_switcher_exclude_builtins| option
-  5. The |g:colorscheme_switcher_command| option
+  3. The |g:colorscheme_switcher_include| option
+  4. The |g:colorscheme_switcher_exclude| option
+  5. The |g:colorscheme_switcher_exclude_builtins| option
+  6. The |g:colorscheme_switcher_command| option
  5. See also                                    |colorscheme-switcher-see-also|
  6. Known problems                        |colorscheme-switcher-known-problems|
  7. Contact                                      |colorscheme-switcher-contact|
@@ -94,6 +95,18 @@ default this is set to 0 (false).
 This is useful when you want to see only light or dark color schemes, for
 example because the sun is shining (you'll want a light background) or because
 it's late at night (then you'll likely prefer a dark background).
+
+-------------------------------------------------------------------------------
+The *g:colorscheme_switcher_include* option
+
+Some plug-ins like vim-colorschemes [9] and base16-vim [10] provide huge
+suites of colorschemes, which are time-consuming to cycle through.  To limit
+switching to just your favorites, you can set a list like this:
+>
+  :let g:colorscheme_switcher_include = ['jellybeans', 'ir_black', 'default']
+<
+The schemes in this option are subject to further filtering by the other
+options.
 
 -------------------------------------------------------------------------------
 The *g:colorscheme_switcher_exclude* option
@@ -193,5 +206,7 @@ References ~
 [6] http://stackoverflow.com/questions/12915797/gvim-remove-syntax-highlighting-groups
 [7] http://www.vim.org/scripts/script.php?script_id=4586
 [8] http://en.wikipedia.org/wiki/MIT_License
+[9] https://github.com/flazz/vim-colorschemes
+[10] https://github.com/chriskempson/base16-vim
 
 vim: ft=help

--- a/doc/colorscheme-switcher.txt
+++ b/doc/colorscheme-switcher.txt
@@ -6,9 +6,9 @@ Contents ~
  1. Introduction                            |colorscheme-switcher-introduction|
  2. Installation                            |colorscheme-switcher-installation|
  3. Commands                                    |colorscheme-switcher-commands|
-  1. The |:NextColorScheme| command
-  2. The |:PrevColorScheme| command
-  3. The |:RandomColorScheme| command
+  1. The |:ColorSchemeNext| command
+  2. The |:ColorSchemePrev| command
+  3. The |:ColorSchemeRandom| command
   4. The |:ColorSchemeToggleBG| command
  4. Options                                      |colorscheme-switcher-options|
   1. The |g:colorscheme_switcher_define_mappings| option
@@ -36,7 +36,7 @@ and mappings to switch to the next and previous color schemes.
 Installation ~
 
 Please refer to the installation instructions [1] available on GitHub. Once
-you've installed the plug-in you can try it out by executing |:NextColorScheme|
+you've installed the plug-in you can try it out by executing |:ColorSchemeNext|
 to switch to the next color scheme.
 
 If you didn't change the plug-in's configuration you can use the 'F8' and
@@ -49,19 +49,19 @@ light and dark color schemes.
 Commands ~
 
 -------------------------------------------------------------------------------
-The *:NextColorScheme* command
+The *:ColorSchemeNext* command
 
 Switch to the next color scheme. After the last color scheme the cycle repeats
 from the first color scheme.
 
 -------------------------------------------------------------------------------
-The *:PrevColorScheme* command
+The *:ColorSchemePrev* command
 
 Switch to the previous color scheme. After the first color scheme the cycle
 repeats from the last color scheme.
 
 -------------------------------------------------------------------------------
-The *:RandomColorScheme* command
+The *:ColorSchemeRandom* command
 
 Switch to a random color scheme. Because Vim doesn't actually expose random
 numbers the microseconds of the current time are used to improvise a source of

--- a/doc/colorscheme-switcher.txt
+++ b/doc/colorscheme-switcher.txt
@@ -9,6 +9,7 @@ Contents ~
   1. The |:NextColorScheme| command
   2. The |:PrevColorScheme| command
   3. The |:RandomColorScheme| command
+  4. The |:ColorSchemeToggleBG| command
  4. Options                                      |colorscheme-switcher-options|
   1. The |g:colorscheme_switcher_define_mappings| option
   2. The |g:colorscheme_switcher_keep_background| option
@@ -39,8 +40,9 @@ you've installed the plug-in you can try it out by executing |:NextColorScheme|
 to switch to the next color scheme.
 
 If you didn't change the plug-in's configuration you can use the 'F8' and
-'Shift-F8' keys to switch to the next/previous color scheme and 'Control-F8' to
-switch to a random color scheme.
+'Shift-F8' keys to switch to the next/previous color scheme, 'Control-F8' to
+switch to a random color scheme and 'Shift-Control-F8' to switch between
+light and dark color schemes.
 
 ===============================================================================
                                                 *colorscheme-switcher-commands*
@@ -65,6 +67,14 @@ Switch to a random color scheme. Because Vim doesn't actually expose random
 numbers the microseconds of the current time are used to improvise a source of
 randomness. It's nothing like real randomness but convincing enough for this
 plug-in :-).
+
+-------------------------------------------------------------------------------
+The *:ColorSchemeToggleBG* command
+
+Switch to the next color scheme with a different background (light/dark). This
+really only makes sense in combination with the
+|g:colorscheme_switcher_keep_background| option (see below).  For when you are
+cycling though dark backgrounds and decide you want a light one instead.
 
 ===============================================================================
                                                  *colorscheme-switcher-options*

--- a/plugin/colorscheme-switcher.vim
+++ b/plugin/colorscheme-switcher.vim
@@ -24,20 +24,25 @@ catch
 endtry
 
 if xolox#misc#option#get('colorscheme_switcher_define_mappings', 1)
-  inoremap <silent> <F8> <C-O>:NextColorScheme<CR>
-  nnoremap <silent> <F8> :NextColorScheme<CR>
-  inoremap <silent> <S-F8> <C-O>:PrevColorScheme<CR>
-  nnoremap <silent> <S-F8> :PrevColorScheme<CR>
-  inoremap <silent> <C-F8> <C-O>:RandomColorScheme<CR>
-  nnoremap <silent> <C-F8> :RandomColorScheme<CR>
+  inoremap <silent> <F8> <C-O>:ColorSchemeNext<CR>
+  nnoremap <silent> <F8> :ColorSchemeNext<CR>
+  inoremap <silent> <S-F8> <C-O>:ColorSchemePrev<CR>
+  nnoremap <silent> <S-F8> :ColorSchemePrev<CR>
+  inoremap <silent> <C-F8> <C-O>:ColorSchemeRandom<CR>
+  nnoremap <silent> <C-F8> :ColorSchemeRandom<CR>
   inoremap <silent> <S-C-F8> <C-O>:ColorSchemeToggleBG<CR>
   nnoremap <silent> <S-C-F8> :ColorSchemeToggleBG<CR>
 endif
 
+command! -bar ColorSchemeNext call xolox#colorscheme_switcher#next()
+command! -bar ColorSchemePrev call xolox#colorscheme_switcher#previous()
+command! -bar ColorSchemeRandom call xolox#colorscheme_switcher#random()
+command! -bar ColorSchemeToggleBG call xolox#colorscheme_switcher#bgtoggle()
+
+" Old command names (deprecated)
 command! -bar NextColorScheme call xolox#colorscheme_switcher#next()
 command! -bar PrevColorScheme call xolox#colorscheme_switcher#previous()
 command! -bar RandomColorScheme call xolox#colorscheme_switcher#random()
-command! -bar ColorSchemeToggleBG call xolox#colorscheme_switcher#bgtoggle()
 
 " Don't reload the plug-in once it has loaded successfully.
 let g:loaded_colorscheme_switcher = 1

--- a/plugin/colorscheme-switcher.vim
+++ b/plugin/colorscheme-switcher.vim
@@ -30,11 +30,14 @@ if xolox#misc#option#get('colorscheme_switcher_define_mappings', 1)
   nnoremap <silent> <S-F8> :PrevColorScheme<CR>
   inoremap <silent> <C-F8> <C-O>:RandomColorScheme<CR>
   nnoremap <silent> <C-F8> :RandomColorScheme<CR>
+  inoremap <silent> <S-C-F8> <C-O>:ColorSchemeToggleBG<CR>
+  nnoremap <silent> <S-C-F8> :ColorSchemeToggleBG<CR>
 endif
 
 command! -bar NextColorScheme call xolox#colorscheme_switcher#next()
 command! -bar PrevColorScheme call xolox#colorscheme_switcher#previous()
 command! -bar RandomColorScheme call xolox#colorscheme_switcher#random()
+command! -bar ColorSchemeToggleBG call xolox#colorscheme_switcher#bgtoggle()
 
 " Don't reload the plug-in once it has loaded successfully.
 let g:loaded_colorscheme_switcher = 1


### PR DESCRIPTION
Very useful plug-in, thanks for sharing!

I have a few commits you may be interested in.
#### Scheme whitelist option

I found it a little daunting to scroll through the 80 color schemes that came in a huge bundle I have, and I didn't want to create a giant exclude list, so I created a new option (`colorscheme_switcher_include`) to limit the selection to the schemes I like best. In my vimrc, I can then set these lists differently for graphical and terminal vim, which is pretty handy.  If someone wanted to get fancy they could even define different sets for different times of day.
#### Scheme set toggle (light/dark)

I really like the `colorscheme_switcher_keep_background` option, since I generally want to choose from all light or all dark backgrounded schemes depending on environmental light.  But what was missing was a quick way to switch between light and dark sets when needed.  So I added a command (`ColorSchemeToggleBG`) to toggle between the two sets and mapped it to `<C-S-F8>`.
#### Let vim calculate background values

When cycling through color schemes with the `colorscheme_switcher_keep_background` option turned on, I noticed it would often skip schemes it should have cycled to.  I figured out that some of the schemes didn't seem to be setting the background value when they load.  But if you do `set background&` after the color scheme has loaded, vim seems to do a good job of correctly setting the background value, at least for all the schemes I was able to try (~80).  
#### Other
- Plugin will now remember the last color scheme it loaded so that if you manually load a color scheme without telling the plugin, it can resume cycling from where it left off rather than starting over again from the beginning of the list.  Good if you have a long list.
- Renamed commands to all start with the common prefix "ColorScheme." This organizes the namespace and makes command tab-completion better.  Old command names are still defined but considered deprecated.
- Changed reported color scheme list index so it goes from (1/n) to (n/n), rather than (0/n) to (n-1/n).

These five commits are pretty clean, so cherry picking should be easy if you want to be selective.  Let me know if you'd rather have separate PRs based from your head.  Doc updates included.
