### PR TITLE
Allow coloschemes with .lua files.

### DIFF
--- a/autoload/xolox/colorscheme_switcher.vim
+++ b/autoload/xolox/colorscheme_switcher.vim
@@ -63,7 +63,10 @@ function! xolox#colorscheme_switcher#find_names() " {{{1
   let matches = {}
   let exclude_list = xolox#misc#option#get('colorscheme_switcher_exclude', [])
   let exclude_builtins = xolox#misc#option#get('colorscheme_switcher_exclude_builtins', 0)
-  for fname in split(globpath(&runtimepath, 'colors/*.vim'), '\n')
+  let vimfiles = split(globpath(&runtimepath, 'colors/*.vim'), '\n')
+  let luafiles =  split(globpath(&runtimepath, 'colors/*.lua'), '\n')
+  let colorfiles = vimfiles + luafiles
+  for fname in colorfiles
     let name = fnamemodify(fname, ':t:r')
     " Ignore names in the exclude list.
     if index(exclude_list, name) == -1


### PR DESCRIPTION
Allow coloschemes with .lua files.

Some newer nvim colorschemes have a "colors/XYZ.lua" file rather than a "colors/XYZ.vim" file.  This change looks for both kinds of files.